### PR TITLE
Add devcontainer configuration for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+
+RUN apt update \ 
+ && apt install -y \
+        curl \
+        jq \
+        libz-dev \
+        make \
+        xz-utils \
+        git \
+ && true
+
+RUN curl -s https://yamlscript.org/install | BIN=1 bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "yamllm container",
+  "build": { "dockerfile": "Dockerfile" },
+  "postAttachCommand": "source .rc"
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -54,6 +54,11 @@ These programs make it nicer to use but are not required:
   npm install -g prettier
   ```
 
+### Using Github Codespaces in a Browser
+
+Use the [Codespace Quickstart
+Link](https://codespaces.new/yaml/yamllm?quickstart=1) to try out yamllm in
+a browser environment.
 
 ## CLI Usage
 


### PR DESCRIPTION
To try it out, go to https://codespaces.new/perlpunk/yamllm/tree/codespace and wait until a terminal appears that you can type in. You should see that `source .rc` was already run.